### PR TITLE
Typo in timer module

### DIFF
--- a/modules/include/tmr.h
+++ b/modules/include/tmr.h
@@ -51,7 +51,7 @@ struct tmr_cfg
 
 // Core module interface functions.
 int32_t tmr_init(struct tmr_cfg* cfg);;
-int32_t tmr_start(void;);
+int32_t tmr_start(void);
 int32_t tmr_run(void);
 
 // Other module-level APIs:


### PR DESCRIPTION
The timer module header file had a typo in the tmr_start interface function